### PR TITLE
Use io::copy in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,26 +30,7 @@ fn main() {
             stdin,
             4096, // buffer size
         );
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf[..]) {
-                Err(e) => {
-                    if let io::ErrorKind::Interrupted = e.kind() {
-                        continue;
-                    }
-                    panic!(e);
-                }
-                Ok(size) => {
-                    if size == 0 {
-                        break;
-                    }
-                    match io::stdout().write_all(&buf[..size]) {
-                        Err(e) => panic!(e),
-                        Ok(_) => {},
-                    }
-                }
-            }
-        }
+        io::copy(&mut reader, &mut io::stdout()).unwrap();
     }   
 }
 ```
@@ -76,34 +57,8 @@ fn main() {
             },
             4096, // internal buffer size
         );
-        let mut buf = [0u8; 4096];
-        loop {
-            match io::stdin().read(&mut buf[..]) {
-                Err(e) => {
-                    if let io::ErrorKind::Interrupted = e.kind() {
-                        continue;
-                    }
-                    panic!(e);
-                }
-                Ok(size) => {
-                    if size == 0 {
-                        match writer.flush() {
-                            Err(e) => {
-                                if let io::ErrorKind::Interrupted = e.kind() {
-                                    continue;
-                                }
-                                panic!(e)
-                            }
-                            Ok(_) => break,
-                        }
-                    }
-                    match writer.write_all(&buf[..size]) {
-                        Err(e) => panic!(e),
-                        Ok(_) => {},
-                    }
-                }
-            }
-        }
+        io::copy(&mut io::stdin(), &mut writer).unwrap();
+        writer.flush().unwrap();
     }
 }
 ```

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -9,7 +9,7 @@ fn main() {
     use std::io;
     let stdout = &mut io::stdout();
     {
-        use std::io::{Read, Write};
+        use std::io::Write;
         let mut writer = divans::DivansBrotliHybridCompressorWriter::new(
             stdout,
             divans::DivansCompressorOptions{
@@ -32,33 +32,7 @@ fn main() {
             },
             4096, // internal buffer size
         );
-        let mut buf = [0u8; 4096];
-        loop {
-            match io::stdin().read(&mut buf[..]) {
-                Err(e) => {
-                    if let io::ErrorKind::Interrupted = e.kind() {
-                        continue;
-                    }
-                    panic!(e);
-                }
-                Ok(size) => {
-                    if size == 0 {
-                        match writer.flush() {
-                            Err(e) => {
-                                if let io::ErrorKind::Interrupted = e.kind() {
-                                    continue;
-                                }
-                                panic!(e)
-                            }
-                            Ok(_) => break,
-                        }
-                    }
-                    match writer.write_all(&buf[..size]) {
-                        Err(e) => panic!(e),
-                        Ok(_) => {},
-                    }
-                }
-            }
-        }
+        io::copy(&mut io::stdin(), &mut writer).unwrap();
+        writer.flush().unwrap();
     }
 }

--- a/examples/decompress.rs
+++ b/examples/decompress.rs
@@ -8,32 +8,12 @@ fn main() {
     use std::io;
     let stdin = &mut io::stdin();
     {
-        use std::io::{Read, Write};
         let mut reader = divans::DivansDecompressorReader::new(
             stdin,
             4096, // buffer size
             false,
             true, // parallel
         );
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf[..]) {
-                Err(e) => {
-                    if let io::ErrorKind::Interrupted = e.kind() {
-                        continue;
-                    }
-                    panic!(e);
-                }
-                Ok(size) => {
-                    if size == 0 {
-                        break;
-                    }
-                    match io::stdout().write_all(&buf[..size]) {
-                        Err(e) => panic!(e),
-                        Ok(_) => {},
-                    }
-                }
-            }
-        }
+        io::copy(&mut reader, &mut io::stdout()).unwrap();
     }   
 }


### PR DESCRIPTION
By using `io::copy` from the std crate, the examples get simpler :).